### PR TITLE
Change Order of Initializers to Remove Warnings

### DIFF
--- a/include/CompoundShapes.hpp
+++ b/include/CompoundShapes.hpp
@@ -19,6 +19,9 @@
 #include <cmath>
 // For sin and cos
 
+#include <algorithm>
+// For std::min
+
 #include "Shape.hpp"
 
 #include "BasicShapes.hpp"
@@ -121,11 +124,13 @@ protected:
 };
 
 
-class Ellipse : public Scaled{
+class Ellipse : public Scaled {
 public:
-	const Circle _circle;
 	Ellipse(double xRadius, double yRadius);
 	virtual ~Ellipse()=default;
+
+protected:
+	const Circle _circle;
 };
 
 #endif // #ifndef FILE_COMPOUNDSHAPES_HPP_INCLUDED

--- a/source/CompoundShapes.cpp
+++ b/source/CompoundShapes.cpp
@@ -246,6 +246,7 @@ std::string Horizontal::generate(point_t center) const
 	return output;
 }
 
-Ellipse::Ellipse(double xRadius, double yRadius): _circle(std::min(xRadius, yRadius)), 
-Scaled(_circle, std::min(xRadius/yRadius, 1.0), std::min(yRadius/xRadius, 1.0))
-{}
+Ellipse::Ellipse(double xRadius, double yRadius)
+: Scaled(_circle, std::min(xRadius/yRadius, 1.0), std::min(yRadius/xRadius, 1.0)),
+  _circle(std::min(xRadius, yRadius))
+{ }


### PR DESCRIPTION
 - Moved _circle after Scaled because it is initialized after
 - Changed some formatting